### PR TITLE
Feature changes

### DIFF
--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from django.conf import settings
 from django.db import connections
 from django.db.backends.postgresql.base import (


### PR DESCRIPTION
This appears to fix the issue with running a `CreateModel` and a `DeleteModel` in the same migration. I also noticed that we still had a hard-coded reference to `core_brand` which I've removed in favour of assuming if the tenant_id is 'id' then create a primary key instead of a composite primary key.